### PR TITLE
changed slip template for outside residents

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/constants/RegistrationConstants.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/constants/RegistrationConstants.java
@@ -2028,7 +2028,7 @@ public class RegistrationConstants {
 	public static final String ACKNOWLEDGEMENT_TEMPLATE = "Ack Template";
 
 	public static final String A6_ACKNOWLEDGEMENT_TEMPLATE_CODE = "reg_ack_a6slip_template_part";
-	public static final String A6_ACKNOWLEDGEMENT_TEMPLATE_CODE_OUTSIDE_UGANDA = "reg_ack_a6slip_template_part_out";
+	public static final String A6_ACKNOWLEDGEMENT_TEMPLATE_CODE_OUTSIDE_UGANDA = "ack_a6slip_template_part_out";
 
 	public static final String A6_THERMAL_PRINTER  = "mosip.registration.ack.printer.a6.thermal";
 


### PR DESCRIPTION
Fixes bug on printing 2 slips when residence is In Uganda. templateService was getting similar slip template type codes for both In Uganda and Outside Uganda. so the fix is to change the type for Outside Uganda.